### PR TITLE
Dockerizes Chartwerk components for deployment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Quickstart
 Once you have installed Docker and docker-compose, running the app locally is easy:
 
 ```
-git clone https://github.com/cjdd3b/django-chartwerk-docker.git
-cd django-chartwerk-docker
+git clone https://github.com/SCPR/docker-admin-chartwerk.git
+cd docker-admin-chartwerk
 docker-compose build
 docker-compose up
 ```

--- a/docker-compose.ec2.yml
+++ b/docker-compose.ec2.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - web
   web:
-    build: .
+    image: scprdev/docker-chartwerk
     env_file:
       - ./config/env/prod.env
     command: ["./scripts/bootstrap.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - web
   web:
-    build: .
+    image: scprdev/docker-chartwerk
     env_file:
       - ./config/env/local.env
     command: ["./scripts/wait-for-it.sh", "db:5432", "--", "./scripts/bootstrap.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Django==1.11.20
 django-chartwerk==0.5.20
 psycopg2==2.7.3.2
 celery==4.1.0
-redis==2.10.6
+redis==3.2.0
 gunicorn==19.7.1


### PR DESCRIPTION
## System diagram

![Chartwerk](https://user-images.githubusercontent.com/16679701/54223008-d54def00-44b3-11e9-8c49-b80e37f49057.png)

The squares (nginx, chartwerk, and redis), are containers that will be spun up into AWS ECS.

After looking at the codebase, it seemed like the admin and frontend of chartwerk didn't need to be separated into their own containers since they both run in the same port. The chartwerk container includes:
- Python 2.7
- Django
- Django-chartwerk
- Chartwerk-editor

The chartwerk container was pushed up to dockerhub with the tag, `scprdev/docker-chartwerk`.